### PR TITLE
Rename "Admin" role to "Host" to be consistent with design decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bedrock"
 version = "0.1.0"
-source = "git+https://github.com/basalt-rs/bedrock.git?rev=4257d82#4257d8232fbe6c4c8305b17c4899a39c7ff5e90b"
+source = "git+https://github.com/basalt-rs/bedrock.git?rev=52ff607#52ff607c8da4a910548a51d9ac290d893e07fd7c"
 dependencies = [
  "comemo",
  "ecow",
@@ -342,6 +342,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "syntect",
  "thiserror 2.0.11",
  "time",
  "tokio",
@@ -350,7 +351,6 @@ dependencies = [
  "typst-kit",
  "typst-pdf",
  "typst-svg",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -2144,6 +2144,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,6 +3494,7 @@ dependencies = [
  "flate2",
  "fnv",
  "once_cell",
+ "onig",
  "plist",
  "regex-syntax 0.8.5",
  "serde",
@@ -4702,12 +4725,6 @@ name = "xmp-writer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb5954c9ca6dcc869e98d3e42760ed9dab08f3e70212b31d7ab8ae7f3b7a487"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ argon2 = { version = "0.5.3", features = ["password-hash"] }
 async-tempfile = "0.6.0"
 axum-extra = { version = "0.10.0", features = ["typed-header"] }
 axum = { version = "0.8.1", features = ["macros", "ws"] }
-bedrock = { git = "https://github.com/basalt-rs/bedrock.git", rev = "4257d82", features = ["tokio"] }
+bedrock = { git = "https://github.com/basalt-rs/bedrock.git", rev = "52ff607", features = ["tokio"] }
 clap = { version = "4.5.23", features = ["derive"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["debug", "from", "deref"] }

--- a/src/repositories/users.rs
+++ b/src/repositories/users.rs
@@ -15,13 +15,13 @@ use crate::storage::SqliteLayer;
 #[serde(rename_all = "kebab-case")]
 pub enum Role {
     Competitor = 0,
-    Admin = 1,
+    Host = 1,
 }
 
 impl From<i32> for Role {
     fn from(value: i32) -> Self {
         match value {
-            1 => Role::Admin,
+            1 => Role::Host,
             _ => Role::Competitor,
         }
     }
@@ -30,7 +30,7 @@ impl From<i32> for Role {
 impl From<i64> for Role {
     fn from(value: i64) -> Self {
         match value {
-            1 => Role::Admin,
+            1 => Role::Host,
             _ => Role::Competitor,
         }
     }
@@ -40,7 +40,7 @@ impl From<Role> for i32 {
     fn from(value: Role) -> Self {
         match value {
             Role::Competitor => 0,
-            Role::Admin => 1,
+            Role::Host => 1,
         }
     }
 }

--- a/src/services/questions.rs
+++ b/src/services/questions.rs
@@ -2,8 +2,8 @@ use crate::server::AppState;
 use axum::{extract::State, Json};
 use bedrock::packet::{Problem, Test};
 use std::collections::BTreeSet;
+use std::ops::Deref;
 use std::sync::Arc;
-use std::{collections::HashSet, ops::Deref};
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 #[derive(serde::Serialize, utoipa::ToSchema)]

--- a/src/services/questions.rs
+++ b/src/services/questions.rs
@@ -1,6 +1,7 @@
 use crate::server::AppState;
 use axum::{extract::State, Json};
 use bedrock::packet::{Problem, Test};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::{collections::HashSet, ops::Deref};
 use utoipa_axum::{router::OpenApiRouter, routes};
@@ -22,7 +23,7 @@ impl From<&Test> for TestResponse {
 
 #[derive(serde::Serialize, utoipa::ToSchema)]
 pub struct QuestionResponse {
-    languages: Option<HashSet<String>>,
+    languages: Option<BTreeSet<String>>,
     title: String,
     description: Option<String>,
     tests: Vec<TestResponse>,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -81,10 +81,10 @@ impl SqliteLayer {
                 .context("Failed to create user")?;
         }
 
-        for admin in &cfg.accounts.admins {
-            create_user(&mut *tx, &admin.name, &admin.password, Role::Host)
+        for host in &cfg.accounts.hosts {
+            create_user(&mut *tx, &host.name, &host.password, Role::Host)
                 .await
-                .context("Failed to create admin user")?;
+                .context("Failed to create host user")?;
         }
 
         tx.commit()

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -82,7 +82,7 @@ impl SqliteLayer {
         }
 
         for admin in &cfg.accounts.admins {
-            create_user(&mut *tx, &admin.name, &admin.password, Role::Admin)
+            create_user(&mut *tx, &admin.name, &admin.password, Role::Host)
                 .await
                 .context("Failed to create admin user")?;
         }

--- a/tests/single.toml
+++ b/tests/single.toml
@@ -21,7 +21,7 @@ trim_output = true
 max_memory = { compile = 128, run = 64 }
 max_file_size = 8192
 
-[[accounts.admins]]
+[[accounts.hosts]]
 name = "Teacher"
 password = "abc123"
 


### PR DESCRIPTION
Updates the "Admin" role to be called "Host" to be consistent with our previous decision to use the term "host".  (I only noticed this was like this because the route on the frontend is `/host` and `/competitor`)

~~There is a similar PR in bedrock to rename the field in the config (https://github.com/basalt-rs/bedrock/pull/9).  Once that is complete, I'll update this PR to update bedrock and make the changes necessary.~~