### PR TITLE
Fix: Run dev container push only on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
 
     push-containers:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        if: github.event_name == 'pull_request'
         needs: [test, clippy]
         permissions:
             contents: read


### PR DESCRIPTION
`ci.yml` ran on both push to main and PR. This was an oversight. It would cause some containers to be tagged `dev-pr--full` etc.