### PR TITLE
fix: correct the status code in creation routes

### DIFF
--- a/basalt-server-lib/src/server/tester.rs
+++ b/basalt-server-lib/src/server/tester.rs
@@ -372,9 +372,12 @@ pub struct CreatedSubmission {
     pub cases: u32,
 }
 
-/// Run a test. Ensure first the the code can compile before breaking off into a separate tokio
-/// task that will then manage the execution of the tests against the compiled artifact for
-/// languages that require a compilation step.
+/// Run a test. Spawns a new tokio task wherein all testing and compilation is handled.
+/// The function will wait for setup to be completed (i.e. compilation if necessary, created
+/// metadata). Afterward, the function will return, but the test may or may not still be
+/// running.
+///
+/// A test can be cancelled via the `Tester::abort` method.
 pub async fn run_test(
     state: Arc<AppState>,
     language: String,

--- a/basalt-server-lib/src/server/tester.rs
+++ b/basalt-server-lib/src/server/tester.rs
@@ -372,6 +372,9 @@ pub struct CreatedSubmission {
     pub cases: u32,
 }
 
+/// Run a test. Ensure first the the code can compile before breaking off into a separate tokio
+/// task that will then manage the execution of the tests against the compiled artifact for
+/// languages that require a compilation step.
 pub async fn run_test(
     state: Arc<AppState>,
     language: String,
@@ -407,7 +410,7 @@ pub async fn run_test(
         let (runner, source_file) = state
             .tester
             .runner(language, question_index)
-            .expect("checked above");
+            .expect("runner should be Some according to check above, but was found to be None");
 
         let compiled = runner
             .file(BorrowedFileContent::string(code), source_file)

--- a/basalt-server-lib/src/services/questions.rs
+++ b/basalt-server-lib/src/services/questions.rs
@@ -178,7 +178,7 @@ pub struct SubmissionBody {
     path = "/{question_index}/submissions", tag = "questions",
     request_body = SubmissionBody,
     responses(
-        (status=OK, body=String, content_type="text/plain", description="The ID of the submission", headers(("Location"))),
+        (status=201, body=String, content_type="text/plain", description="The ID of the submission", headers(("Location"))),
         (status=400, description="Invalid data provided"),
         (status=404, description="Question or language not found"),
         (status=409, description="Competition is paused"),
@@ -225,7 +225,7 @@ pub async fn create_submission(
     path = "/{question_index}/tests", tag = "questions",
     request_body = SubmissionBody,
     responses(
-        (status=OK, body=String, content_type="text/plain", description="The ID of the submission", headers(("Location"))),
+        (status=201, body=String, content_type="text/plain", description="The ID of the submission", headers(("Location"))),
         (status=400, description="Invalid data provided"),
         (status=404, description="Question or language not found"),
         (status=409, description="Competition is paused"),


### PR DESCRIPTION
The creation routes were documented to respond with 200 OK on successful creation. This is inaccurate. 