### PR TITLE
Use In-Memory Database for Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: true
-            - name: install dependencies (ubuntu only)
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install protobuf-compiler
+            - uses: actions/cache@v5.0.4
+              with:
+                path: target
+                key: ${{ runner.os }}-target
             - name: Install ${{ matrix.toolchain }}
               uses: dtolnay/rust-toolchain@master
               with:
@@ -82,10 +82,10 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   submodules: true
-            - name: install dependencies (ubuntu only)
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install protobuf-compiler
+            - uses: actions/cache@v5.0.4
+              with:
+                path: target
+                key: ${{ runner.os }}-target
             - uses: dtolnay/rust-toolchain@master
               with:
                   toolchain: stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "async-tempfile",
  "axum 0.8.4",
  "axum-extra",
  "bedrock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8a57b75c36e16f4d015e60e6a177552976a99b6947724403c551bcfa7cb1207"
 dependencies = [
  "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -541,7 +540,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
- "async-tempfile",
  "axum 0.8.4",
  "axum-extra",
  "bedrock",

--- a/basalt-server-lib/Cargo.toml
+++ b/basalt-server-lib/Cargo.toml
@@ -17,7 +17,6 @@ uninlined_format_args = "allow"
 [dependencies]
 anyhow.workspace = true
 argon2.workspace = true
-async-tempfile.workspace = true
 axum-extra.workspace = true
 axum.workspace = true
 bedrock.workspace = true
@@ -47,7 +46,6 @@ futures = "0.3.31"
 ident-str = "0.1.0"
 
 [dev-dependencies]
-async-tempfile = { workspace = true, features = ["uuid"] }
 tracing-subscriber.workspace = true
 
 [build-dependencies]

--- a/basalt-server-lib/Cargo.toml
+++ b/basalt-server-lib/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 rust-version.workspace = true
 
 [features]
+testing = ["dep:tracing-subscriber"]
 doc-gen = []
 webhooks = ["dep:reqwest"]
 scripting = ["dep:rustyscript"]
@@ -44,6 +45,7 @@ rustyscript = { git = "https://github.com/rscarson/rustyscript.git", branch = "m
 reqwest = { version = "0.13.2", features = ["json"], optional = true }
 futures = "0.3.31"
 ident-str = "0.1.0"
+tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/basalt-server-lib/Cargo.toml
+++ b/basalt-server-lib/Cargo.toml
@@ -49,6 +49,7 @@ tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
 tracing-subscriber.workspace = true
+async-tempfile.workspace = true
 
 [build-dependencies]
 tokio = { version = "1.43.0", features = ["full"] }

--- a/basalt-server-lib/build.rs
+++ b/basalt-server-lib/build.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::Context;
 
@@ -8,14 +8,7 @@ pub async fn main() -> anyhow::Result<()> {
     let cargo_target_dir =
         std::env::var("OUT_DIR").context("Failed to get cargo target directory")?;
 
-    let path = PathBuf::from(cargo_target_dir)
-        .join("initial_data")
-        .with_extension("db");
-
-    println!(
-        "cargo::rustc-env=INITIAL_DATA_PATH={}",
-        path.to_str().unwrap()
-    );
+    let path = Path::new(&cargo_target_dir).join("initial_data.db");
 
     let sqlite_uri = format!("sqlite:{}", path.to_str().unwrap());
 

--- a/basalt-server-lib/src/lib.rs
+++ b/basalt-server-lib/src/lib.rs
@@ -5,5 +5,5 @@ mod services;
 pub mod storage;
 mod utils;
 
-#[cfg(test)]
-mod testing;
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;

--- a/basalt-server-lib/src/repositories/announcements.rs
+++ b/basalt-server-lib/src/repositories/announcements.rs
@@ -100,7 +100,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_announcement() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
         let user = dummy_user(&sql, "dummy_user", "foobar", Role::Competitor).await;
         let announcement = super::create_announcement(&sql, &user.id, "hello world")
             .await
@@ -108,12 +108,11 @@ mod tests {
 
         assert_eq!(announcement.sender, user.id);
         assert_eq!(&announcement.message, "hello world");
-        drop(f)
     }
 
     #[tokio::test]
     async fn get_announcements() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
         let user = dummy_user(&sql, "dummy_user", "foobar", Role::Competitor).await;
         super::create_announcement(&sql, &user.id, "foo")
             .await
@@ -126,12 +125,11 @@ mod tests {
 
         assert!(ann.iter().any(|a| a.message == "foo"));
         assert!(ann.iter().any(|a| a.message == "bar"));
-        drop(f)
     }
 
     #[tokio::test]
     async fn delete_announcement() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
         let user = dummy_user(&sql, "dummy_user", "foobar", Role::Competitor).await;
         let Announcement { id, .. } = super::create_announcement(&sql, &user.id, "foo")
             .await
@@ -145,6 +143,5 @@ mod tests {
 
         let ann = super::get_announcements(&sql).await.unwrap();
         assert!(ann.is_empty());
-        drop(f)
     }
 }

--- a/basalt-server-lib/src/repositories/submissions.rs
+++ b/basalt-server-lib/src/repositories/submissions.rs
@@ -525,7 +525,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_submission() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
         let user = dummy_user(&sql, "dummy_user", "foobar", Role::Competitor).await;
         let history = create_submission_history(
             &sql,
@@ -553,12 +553,11 @@ mod tests {
         assert_eq!(history.question_index, 42);
         assert_eq!(history.score, 42.);
         assert!(!history.success);
-        drop(f)
     }
 
     #[tokio::test]
     async fn create_submission_test() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
         let user = dummy_user(&sql, "dummy_user", "foobar", Role::Competitor).await;
         let history = create_submission_history(
             &sql,
@@ -595,12 +594,11 @@ mod tests {
         assert_eq!(test.stdout, "stdout");
         assert_eq!(test.stderr, "stderr");
         assert_eq!(test.exit_status, 1);
-        drop(f)
     }
 
     #[tokio::test]
     async fn other_submissions() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
 
         for i in 0..5 {
             let user = dummy_user(
@@ -652,13 +650,11 @@ mod tests {
 
         let n = count_other_submissions(&sql, 1).await.unwrap();
         assert_eq!(n, 5);
-
-        drop(f)
     }
 
     #[tokio::test]
     async fn previous_submissions() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
 
         let user = dummy_user(&sql, "dummy_user", "foobar", Role::Competitor).await;
         for _ in 0..5 {
@@ -685,13 +681,11 @@ mod tests {
 
         let n = count_previous_submissions(&sql, &user.id, 1).await.unwrap();
         assert_eq!(n, 5);
-
-        drop(f)
     }
 
     #[tokio::test]
     async fn user_score() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
 
         let user = dummy_user(&sql, "dummy_user", "foobar", Role::Competitor).await;
         for i in 0..5 {
@@ -716,13 +710,11 @@ mod tests {
 
         let n = get_user_score(&sql, &user.id).await.unwrap();
         assert_eq!(n, 42. * 5.);
-
-        drop(f)
     }
 
     #[tokio::test]
     async fn latest_submissions() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
 
         let user = dummy_user(&sql, "dummy_user", "foobar", Role::Competitor).await;
         for i in 0..5 {
@@ -772,7 +764,5 @@ mod tests {
         for s in submissions {
             assert_eq!(s.code, "latest");
         }
-
-        drop(f)
     }
 }

--- a/basalt-server-lib/src/repositories/users.rs
+++ b/basalt-server-lib/src/repositories/users.rs
@@ -220,15 +220,14 @@ mod tests {
     use super::*;
     #[tokio::test]
     async fn get_nonexistent_user() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
         let response = get_user_by_id(&sql, &UserId::new()).await;
         assert!(response.is_err());
-        drop(f)
     }
 
     #[tokio::test]
     async fn get_existing_user_by_id() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
         let dummy_user = create_user(
             &sql,
             "awesome_user".to_string(),
@@ -242,12 +241,11 @@ mod tests {
             .await
             .expect("Failed to find user");
         assert_eq!(user.username, dummy_user.username);
-        drop(f)
     }
 
     #[tokio::test]
     async fn get_correct_user() {
-        let (f, sql) = mock_db().await;
+        let sql = mock_db().await;
         let dummy_user = crate::testing::users_repositories::dummy_user(
             &sql,
             "awesome_user".to_string(),
@@ -266,6 +264,5 @@ mod tests {
             .await
             .expect("Failed to find user");
         assert_eq!(user.username, dummy_user.username);
-        drop(f)
     }
 }

--- a/basalt-server-lib/src/services/questions.rs
+++ b/basalt-server-lib/src/services/questions.rs
@@ -639,13 +639,9 @@ mod test {
     async fn get_all_questions_competitor() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+        };
 
         let Json(value) = get_all(user!("foobar", Competitor).into(), State(state)).await;
 
@@ -682,13 +678,9 @@ mod test {
     async fn get_all_questions_host() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+        };
         let Json(value) = get_all(user!("foobar", Host).into(), State(state)).await;
 
         assert_eq!(
@@ -738,13 +730,9 @@ mod test {
     async fn get_specific_question_host() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+        };
 
         let Json(value) = get_specific_question(
             State(state),
@@ -781,13 +769,9 @@ mod test {
     async fn get_specific_question_competitor() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+        };
 
         let Json(value) = get_specific_question(
             State(state),
@@ -817,13 +801,9 @@ mod test {
     async fn get_specific_question_404() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+        };
 
         let code = get_specific_question(
             State(state),
@@ -840,14 +820,10 @@ mod test {
     async fn create_submission_valid() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
 
@@ -882,14 +858,10 @@ mod test {
     async fn create_submission_404() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         state.clock.write().await.unpause();
 
@@ -916,14 +888,10 @@ mod test {
     async fn create_submission_paused() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         state.clock.write().await.pause();
 
@@ -950,14 +918,10 @@ mod test {
     async fn create_test_valid() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
 
@@ -992,14 +956,10 @@ mod test {
     async fn create_test_404() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         state.clock.write().await.unpause();
 
@@ -1026,14 +986,10 @@ mod test {
     async fn create_test_paused() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         state.clock.write().await.pause();
 
@@ -1060,14 +1016,10 @@ mod test {
     async fn get_submission_valid() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
         let history = insert_submission(&state.db, user.id, false).await;
@@ -1096,14 +1048,10 @@ mod test {
     async fn get_submission_404() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let submission_id = SubmissionId::new();
         state.clock.write().await.unpause();
@@ -1123,14 +1071,10 @@ mod test {
     async fn get_submission_test() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
         let history = insert_submission(&state.db, user.id, true).await;
@@ -1148,14 +1092,10 @@ mod test {
     async fn get_submission_other_user() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
         let history = insert_submission(&state.db, user.id, false).await;
@@ -1177,14 +1117,10 @@ mod test {
     async fn get_submission_other_user_host() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
         let history = insert_submission(&state.db, user.id, false).await;
@@ -1218,14 +1154,10 @@ mod test {
     async fn get_test_valid() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
         let history = insert_submission(&state.db, user.id, true).await;
@@ -1255,14 +1187,10 @@ mod test {
     async fn get_test_404() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let submission_id = SubmissionId::new();
         state.clock.write().await.unpause();
@@ -1282,14 +1210,10 @@ mod test {
     async fn get_test_submission() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
         let history = insert_submission(&state.db, user.id, false).await;
@@ -1307,14 +1231,10 @@ mod test {
     async fn get_test_other_user() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
         let history = insert_submission(&state.db, user.id, true).await;
@@ -1336,14 +1256,10 @@ mod test {
     async fn get_test_other_user_host() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![RUST_LANG],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![RUST_LANG],
+        };
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
         let history = insert_submission(&state.db, user.id, true).await;
@@ -1377,14 +1293,10 @@ mod test {
     async fn abort_submission_valid() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1424,14 +1336,10 @@ mod test {
     async fn abort_submission_404() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1451,14 +1359,10 @@ mod test {
     async fn abort_submission_test() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1490,14 +1394,10 @@ mod test {
     async fn abort_submission_other_user() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1529,14 +1429,10 @@ mod test {
     async fn abort_submission_other_user_host() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1576,14 +1472,10 @@ mod test {
     async fn abort_test_valid() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1623,14 +1515,10 @@ mod test {
     async fn abort_test_404() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1650,14 +1538,10 @@ mod test {
     async fn abort_test_submission() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1689,14 +1573,10 @@ mod test {
     async fn abort_test_other_user() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;
@@ -1728,14 +1608,10 @@ mod test {
     async fn abort_test_other_user_host() {
         setup_test_logger();
 
-        mock_state!(
-            let state;
-            Config {
-                packet: double_problem_packet(),
-                languages: language_set![sleep_lang()],
-                ..Config::default()
-            }
-        );
+        let state = mock_state! {
+            packet: double_problem_packet(),
+            languages: language_set![sleep_lang()],
+        };
         state.clock.write().await.unpause();
 
         let user = db_user(&state.db, "foobar", Role::Competitor).await;

--- a/basalt-server-lib/src/services/teams.rs
+++ b/basalt-server-lib/src/services/teams.rs
@@ -267,7 +267,7 @@ mod tests {
     use super::*;
     #[tokio::test]
     async fn get_teams_works() {
-        let (f, db) = mock_db().await;
+        let db = mock_db().await;
 
         let expected_score = 3.0;
 
@@ -303,6 +303,5 @@ mod tests {
                 .score,
             expected_score
         );
-        drop(f);
     }
 }

--- a/basalt-server-lib/src/storage/mod.rs
+++ b/basalt-server-lib/src/storage/mod.rs
@@ -2,8 +2,8 @@ use anyhow::Context;
 use bedrock::Config;
 use derive_more::Deref;
 use futures::{future::BoxFuture, stream::BoxStream};
-use std::str::FromStr;
-use tokio::io::AsyncWriteExt;
+use std::{path::Path, str::FromStr};
+use tokio::fs::File;
 use tracing::debug;
 
 use sqlx::{
@@ -12,8 +12,6 @@ use sqlx::{
 };
 
 use crate::repositories::users::{create_user, Role};
-
-const INITIAL_DB_CONTENT: &[u8] = include_bytes!(env!("INITIAL_DATA_PATH"));
 
 #[derive(Debug, Deref)]
 pub struct SqliteLayer {
@@ -33,30 +31,42 @@ impl SqliteLayer {
     /// # };
     /// ```
     pub async fn new(title: impl AsRef<str>) -> anyhow::Result<(bool, Self)> {
-        let mut path = directories::ProjectDirs::from("rs", "basalt", "basalt-server")
+        let path = directories::ProjectDirs::from("rs", "basalt", "basalt-server")
             .context("Failed to resolve project directory")?
             .data_local_dir()
-            .join(title.as_ref());
-        tokio::fs::create_dir_all(&path)
-            .await
-            .expect("failed to create database files");
-        path = path.join("data").with_extension("db");
-        let init = !path.exists();
+            .join(title.as_ref())
+            .join("data.db");
 
+        Self::from_path(&path).await
+    }
+
+    /// Create a new instance of the database at a specific path
+    async fn from_path(path: impl AsRef<Path>) -> anyhow::Result<(bool, Self)> {
+        let path = path.as_ref();
+
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .context("creating database file")?;
+        }
+
+        let init = !path.exists();
         if init {
-            let mut file = tokio::fs::File::create(&path)
+            File::create_new(path)
                 .await
-                .context("Failed to create datafile")?;
-            file.write_all(INITIAL_DB_CONTENT)
-                .await
-                .context("Failed to write datafile")?;
+                .context("creating database file")?;
         }
 
         debug!(?path, "Connecting to sqlite database");
-        let db = sqlx::sqlite::SqlitePool::connect(path.as_path().to_str().unwrap())
+        let db = sqlx::sqlite::SqlitePool::connect(path.to_str().unwrap())
             .await
             .context("Failed to connect to SQLiteDB")?;
-        Ok((init, Self { db }))
+
+        // aways intialise, in case new tables need to be created
+        let this = Self { db };
+        this.init_db().await?;
+
+        Ok((init, this))
     }
 
     /// Create a new [`SqliteLayer`] using an in-memory database, primarily for testing
@@ -70,11 +80,20 @@ impl SqliteLayer {
             .await
             .context("Failed to connect to SQLite DB")?;
 
-        sqlx::raw_sql(include_str!("../.././migration.sql"))
-            .execute(&db)
-            .await?;
+        let this = Self { db };
 
-        Ok(Self { db })
+        this.init_db().await?;
+
+        Ok(this)
+    }
+
+    /// Run the migration.sql to initialise the database tables
+    async fn init_db(&self) -> anyhow::Result<()> {
+        sqlx::raw_sql(include_str!("../../migration.sql"))
+            .execute(&self.db)
+            .await
+            .context("Intialising Database")?;
+        Ok(())
     }
 
     pub async fn ingest(&self, cfg: &Config) -> anyhow::Result<()> {
@@ -170,7 +189,11 @@ impl<'a> Executor<'a> for &SqliteLayer {
 
 #[cfg(test)]
 mod tests {
-    use crate::testing::mock_db;
+    use crate::{
+        repositories::users::{create_user, Role},
+        storage::SqliteLayer,
+        testing::{mock_db, users_repositories::get_user_by_username},
+    };
     use bedrock::Config;
 
     #[tokio::test]
@@ -184,5 +207,34 @@ mod tests {
         let db = mock_db().await;
 
         db.ingest(&cfg).await.expect("Failed to ingest config");
+    }
+
+    #[tokio::test]
+    async fn persistent_database() {
+        // NOTE: using a tempdir so the file itself isn't created
+        let tempdir = async_tempfile::TempDir::new().await.unwrap();
+
+        let file = tempdir.join("database.db");
+        assert!(!tokio::fs::try_exists(&file).await.unwrap());
+
+        let (init, layer) = SqliteLayer::from_path(&file).await.unwrap();
+        assert!(init);
+        create_user(&layer, "foo", None, "password", Role::Host)
+            .await
+            .unwrap();
+
+        layer.close().await;
+        drop(layer);
+
+        let (init, layer) = SqliteLayer::from_path(&file).await.unwrap();
+        assert!(!init);
+
+        let user = get_user_by_username(&layer, "foo").await.unwrap();
+        assert_eq!(user.username, "foo");
+        assert_eq!(user.display_name, None);
+        assert_eq!(user.role, Role::Host);
+
+        layer.close().await;
+        drop(layer);
     }
 }

--- a/basalt-server-lib/src/storage/mod.rs
+++ b/basalt-server-lib/src/storage/mod.rs
@@ -2,7 +2,6 @@ use anyhow::Context;
 use bedrock::Config;
 use derive_more::Deref;
 use futures::{future::BoxFuture, stream::BoxStream};
-use std::path::Path;
 use std::str::FromStr;
 use tokio::io::AsyncWriteExt;
 use tracing::debug;
@@ -60,8 +59,7 @@ impl SqliteLayer {
         Ok((init, Self { db }))
     }
 
-    /// Create a new [`SqliteLayer`] using an in-memory database
-    #[cfg(test)] // This is only really useful for testing
+    /// Create a new [`SqliteLayer`] using an in-memory database, primarily for testing
     pub async fn in_memory() -> anyhow::Result<Self> {
         let opts = SqliteConnectOptions::from_str("sqlite::memory:")
             .expect("from_str is given a valid URI")
@@ -76,28 +74,6 @@ impl SqliteLayer {
             .execute(&db)
             .await?;
 
-        Ok(Self { db })
-    }
-
-    /// Create anew [`SqliteLayer`] using a path to the database
-    ///
-    /// The database file will be initalised if it does not exist.
-    pub async fn from_path(value: impl AsRef<Path>) -> anyhow::Result<Self> {
-        let mut file = tokio::fs::File::create(value.as_ref())
-            .await
-            .context("Failed to create datafile")?;
-        file.write_all(INITIAL_DB_CONTENT)
-            .await
-            .context("Failed to write default database to datafile")?;
-        drop(file);
-        let uri = format!("sqlite://{}", value.as_ref().to_str().unwrap());
-        let opts = SqliteConnectOptions::from_str(&uri)
-            .context("Invalid options")?
-            .journal_mode(SqliteJournalMode::Wal)
-            .read_only(false);
-        let db = sqlx::sqlite::SqlitePool::connect_with(opts)
-            .await
-            .context("Failed to connect to SQLite DB")?;
         Ok(Self { db })
     }
 

--- a/basalt-server-lib/src/storage/mod.rs
+++ b/basalt-server-lib/src/storage/mod.rs
@@ -59,7 +59,29 @@ impl SqliteLayer {
             .context("Failed to connect to SQLiteDB")?;
         Ok((init, Self { db }))
     }
-    /// Converts a `Pathbuf` to a `SqliteLayer`
+
+    /// Create a new [`SqliteLayer`] using an in-memory database
+    #[cfg(test)] // This is only really useful for testing
+    pub async fn in_memory() -> anyhow::Result<Self> {
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:")
+            .expect("from_str is given a valid URI")
+            .journal_mode(SqliteJournalMode::Wal)
+            .read_only(false);
+
+        let db = sqlx::sqlite::SqlitePool::connect_with(opts)
+            .await
+            .context("Failed to connect to SQLite DB")?;
+
+        sqlx::raw_sql(include_str!("../.././migration.sql"))
+            .execute(&db)
+            .await?;
+
+        Ok(Self { db })
+    }
+
+    /// Create anew [`SqliteLayer`] using a path to the database
+    ///
+    /// The database file will be initalised if it does not exist.
     pub async fn from_path(value: impl AsRef<Path>) -> anyhow::Result<Self> {
         let mut file = tokio::fs::File::create(value.as_ref())
             .await
@@ -182,9 +204,9 @@ mod tests {
             Some("single.toml"),
         )
         .unwrap();
-        let (f, db) = mock_db().await;
-        db.ingest(&cfg).await.expect("Failed to ingest config");
 
-        drop(f)
+        let db = mock_db().await;
+
+        db.ingest(&cfg).await.expect("Failed to ingest config");
     }
 }

--- a/basalt-server-lib/src/testing/mod.rs
+++ b/basalt-server-lib/src/testing/mod.rs
@@ -37,15 +37,19 @@ pub fn setup_test_logger() {
 /// ```
 #[macro_export]
 macro_rules! mock_state {
-    (let $state: ident) => {
-        mock_state!($state, Config::default());
-    };
-    (let $state: ident; $config: expr) => {
+    ($($cfg_key: ident: $cfg_value: expr),*$(,)?) => {{
         let db = $crate::testing::mock_db().await;
-        let mut state = AppState::new(db, $config, None);
-        state.init().await.unwrap();
-        let $state = Arc::new(state);
-    };
+        let mut state = $crate::server::AppState::new(
+            db,
+            bedrock::Config {
+                $($cfg_key: $cfg_value,)*
+                ..Default::default()
+            },
+            None
+        );
+        state.init().await.unwrap() ;
+        std::sync::Arc::new(state)
+    }};
 }
 
 /// Create a mock user

--- a/basalt-server-lib/src/testing/mod.rs
+++ b/basalt-server-lib/src/testing/mod.rs
@@ -32,8 +32,12 @@ pub fn setup_test_logger() {
 /// Assigns `Arc<AppState>` to the variable name passed in
 ///
 /// ```
-/// mock_state!(let state);
-/// mock_state!(let state; Config { .. });
+/// let state = mock_state! {};
+///
+/// // If config fields need to be specified:
+/// let state = mock_state! {
+///     packet: Default::default(),
+/// };
 /// ```
 #[macro_export]
 macro_rules! mock_state {

--- a/basalt-server-lib/src/testing/mod.rs
+++ b/basalt-server-lib/src/testing/mod.rs
@@ -13,16 +13,10 @@ pub mod users_repositories;
 
 pub const SAMPLE_1: &str = include_str!("../../../samples/single.toml");
 
-pub async fn mock_db() -> (async_tempfile::TempFile, SqliteLayer) {
-    let db_tempfile = async_tempfile::TempFile::new()
+pub async fn mock_db() -> SqliteLayer {
+    SqliteLayer::in_memory()
         .await
-        .expect("Failed to create temporary file for datafile");
-
-    let sqlite_layer = SqliteLayer::from_path(db_tempfile.file_path())
-        .await
-        .expect("Failed to create SqliteDB");
-
-    (db_tempfile, sqlite_layer)
+        .expect("Failed to create SqliteDB")
 }
 
 pub fn setup_test_logger() {
@@ -47,7 +41,7 @@ macro_rules! mock_state {
         mock_state!($state, Config::default());
     };
     (let $state: ident; $config: expr) => {
-        let (_db_file, db) = $crate::testing::mock_db().await;
+        let db = $crate::testing::mock_db().await;
         let mut state = AppState::new(db, $config, None);
         state.init().await.unwrap();
         let $state = Arc::new(state);

--- a/basalt-server/Cargo.toml
+++ b/basalt-server/Cargo.toml
@@ -32,6 +32,7 @@ tracing.workspace = true
 [build-dependencies]
 basalt-server-lib = { path = "../basalt-server-lib", features = [
     "doc-gen",
+    "testing",
 ], default-features = false }
 anyhow.workspace = true
 async-tempfile.workspace = true

--- a/basalt-server/build.rs
+++ b/basalt-server/build.rs
@@ -45,23 +45,11 @@ pub async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "doc-gen")]
     {
         use anyhow::Context;
-        use basalt_server_lib::{server::AppState, storage::SqliteLayer};
-        use std::{path::Path, sync::Arc};
+        use basalt_server_lib::mock_state;
+        use std::path::Path;
         use utoipa::OpenApi;
 
-        let tempfile = async_tempfile::TempFile::new()
-            .await
-            .context("Failed to create tempfile")?;
-
-        let sqlite_layer = SqliteLayer::from_path(tempfile.file_path())
-            .await
-            .context("Failed to create sqlite layer")?;
-
-        let dummy_state = Arc::new(AppState::new(
-            sqlite_layer,
-            bedrock::Config::default(),
-            None,
-        ));
+        let dummy_state = mock_state! {};
         let router = basalt_server_lib::server::doc_router(dummy_state);
 
         #[derive(OpenApi)]


### PR DESCRIPTION
Switch to using an in-memory database for testing.  This makes tests use a bit more memory (though not significantly), but seems to fix the spurious errors that we have been getting in CI.

I am able to force the errors on main locally by using this fish command:

```fish
for x in (seq 1 20)
    cargo t -q -j 1 -- --test-threads=24 &
end
wait
```

I think the bash equivalent is this, but I haven't tested it:

```bash
for x in $(seq 1 20); do
    cargo t -q -j 1 -- --test-threads=24 &
done
wait
```

The issues do not seem to persist locally when using an in-memory database, but this PR should be a better indicator as to whether it persists in CI.

Resolve #62